### PR TITLE
Expose contour level

### DIFF
--- a/Lib/glyphtracy/__init__.py
+++ b/Lib/glyphtracy/__init__.py
@@ -103,6 +103,7 @@ class Vectorizer:
         extrema_min_index_gap: int = 3,
         extrema_min_span_points: int = 8,
         extrema_max_iterations: int = 8,
+        contour_level: float = 0.5,
         fit_tolerance: float = 5.0,
         node_balance_weight: float = 0.8,
         segment_balance_weight: float = 0.8,
@@ -120,6 +121,8 @@ class Vectorizer:
             extrema_min_index_gap: Minimum gap between detected extrema nodes (at reference size).
             extrema_min_span_points: Minimum points in extrema search spans (at reference size).
             extrema_max_iterations: Max iterations for iterative extrema search.
+            contour_level: Iso-value threshold for contour extraction (default: 0.5).
+                Lower values include lighter ink, connecting faint joins. Too low picks up noise.
             fit_tolerance: Max error tolerance for Bezier fitting (pixels at reference size).
             node_balance_weight: Weight for incoming/outgoing handle balance.
             segment_balance_weight: Weight for segment-level handle balance.
@@ -152,6 +155,7 @@ class Vectorizer:
         self.handle_shrink_weight = float(handle_shrink_weight)
         self.max_split_depth = int(max_split_depth)
         self.extrema_max_iterations = int(extrema_max_iterations)
+        self.contour_level = float(contour_level)
 
         # Resolution-dependent parameters (scaled by resolution_scale)
         self.fit_tolerance = float(fit_tolerance) * self.resolution_scale
@@ -250,7 +254,7 @@ class Vectorizer:
         """Extract contours from image using skimage."""
         contours: list[Contour] = []
         for contour_id, contour in enumerate(
-            skimage.measure.find_contours(self.image_array, level=0.5)
+            skimage.measure.find_contours(self.image_array, level=self.contour_level)
         ):
             rc = dedupe_closed_contour(np.asarray(contour, dtype=np.float64))
             if rc.shape[0] < 3:
@@ -635,6 +639,14 @@ def main():
         default=8,
         help="Max iterations for iterative extrema search (default: 8).",
     )
+    node_group.add_argument(
+        "--contour-level",
+        type=float,
+        default=0.5,
+        help="Iso-value threshold for contour extraction (default: 0.5). "
+             "Lower values include lighter ink, connecting faint joins. "
+             "Too low picks up paper texture noise.",
+    )
 
     fit_group = parser.add_argument_group("Path fitting parameters")
     fit_group.add_argument(
@@ -683,6 +695,7 @@ def main():
         g2_weight=args.g2_weight,
         handle_shrink_weight=args.handle_shrink_weight,
         max_split_depth=args.max_split_depth,
+        contour_level=args.contour_level,
         sharp_threshold=args.sharp_threshold,
         pixel_tolerance=args.pixel_tolerance,
         extrema_min_index_gap=args.extrema_min_index_gap,

--- a/glyphtracy-ts/src/index.ts
+++ b/glyphtracy-ts/src/index.ts
@@ -18,6 +18,7 @@ export interface VectorizerOptions {
   extremaMinIndexGap?: number;
   extremaMinSpanPoints?: number;
   extremaMaxIterations?: number;
+  contourLevel?: number;
   fitTolerance?: number;
   nodeBalanceWeight?: number;
   segmentBalanceWeight?: number;
@@ -139,6 +140,7 @@ export class Vectorizer {
   extremaMinIndexGap: number;
   extremaMinSpanPoints: number;
   extremaMaxIterations: number;
+  contourLevel: number;
   fitTolerance: number;
   nodeBalanceWeight: number;
   segmentBalanceWeight: number;
@@ -162,6 +164,7 @@ export class Vectorizer {
     this.handleShrinkWeight = options.handleShrinkWeight ?? 0.05;
     this.maxSplitDepth = options.maxSplitDepth ?? 5;
     this.extremaMaxIterations = options.extremaMaxIterations ?? 8;
+    this.contourLevel = options.contourLevel ?? 0.5;
 
     this.fitTolerance = (options.fitTolerance ?? 5) * this.resolutionScale;
     this.pixelTolerance =
@@ -177,7 +180,7 @@ export class Vectorizer {
   }
 
   extractContours(): Contour[] {
-    let raw = isoLines(this.imageArray, 0.5) ?? [];
+    let raw = isoLines(this.imageArray, this.contourLevel) ?? [];
     // First one is always the image boundary, skip it
     raw = raw.slice(1);
     const contours: Contour[] = [];


### PR DESCRIPTION
Adjusting the contour level helps trace glyphs with thin joins

Original image:
<img width="70" height="65" alt="lowercase n-m-22" src="https://github.com/user-attachments/assets/659d3ae9-3c24-4b48-b86c-0ac97d986967" />

Before:
<img width="438" height="130" alt="image" src="https://github.com/user-attachments/assets/77f3f7ca-4480-4c92-9b57-cec2d3177efe" />

After:
<img width="443" height="140" alt="image" src="https://github.com/user-attachments/assets/3bb2ec98-c7ed-4030-ae9d-00108c94870a" />
